### PR TITLE
Correct percentage gain/loss calculations.

### DIFF
--- a/app/src/main/kotlin/com/github/premnirmal/ticker/network/data/Quote.kt
+++ b/app/src/main/kotlin/com/github/premnirmal/ticker/network/data/Quote.kt
@@ -104,7 +104,7 @@ data class Quote(var symbol: String = "") : Comparable<Quote> {
     return gainLossString
   }
 
-  private fun gainLossPercent(): Float = (gainLoss() / holdings()) * 100f
+  private fun gainLossPercent(): Float = (gainLoss() / totalPositionPrice()) * 100f
 
   fun gainLossPercentString(): String {
     val gainLossPercent = gainLossPercent()


### PR DESCRIPTION
In gain/loss calculations, divide by the price *paid* for holdings, not the current value of the holdings. (If a $100 investment yesterday is now worth $125, the gain is 25/100 = 25%, not 25/125 = 20%.)