### PR TITLE
Fix issues of inconsistent colors in ProgressBar

### DIFF
--- a/app/src/main/res/layout/widget_header.xml
+++ b/app/src/main/res/layout/widget_header.xml
@@ -67,6 +67,7 @@
         android:layout_height="@dimen/widget_refresh_icon_size"
         android:layout_gravity="center"
         android:indeterminateTint="@color/text_widget_header"
+        android:indeterminateTintMode="src_in"
         android:progressTint="@color/text_widget_header"
         android:visibility="gone"
         />


### PR DESCRIPTION
Hi,

I have found there is an issue in the ProgressBar in `widget_header.xml`. Here, you only set the attribute `android:indeterminateTint` without setting `android:indeterminateTintMode`, which can cause the color not applicable in API level < 23. I submit a pull request, which sets `android:indeterminateTintMode="src_in"` to fix this issue.