### PR TITLE
Add invert font color settings red/green

### DIFF
--- a/app/src/main/kotlin/com/github/premnirmal/ticker/AppPreferences.kt
+++ b/app/src/main/kotlin/com/github/premnirmal/ticker/AppPreferences.kt
@@ -138,6 +138,14 @@ class AppPreferences {
         .apply()
   }
 
+  fun invertColors(): Boolean = sharedPreferences.getBoolean(SETTING_INVERT_COLORS, false)
+
+  fun setInvertColors(round: Boolean){
+    sharedPreferences.edit()
+            .putBoolean(SETTING_INVERT_COLORS, round)
+            .apply()
+  }
+
   fun notificationAlerts(): Boolean = sharedPreferences.getBoolean(SETTING_NOTIFICATION_ALERTS, true)
 
   fun setNotificationAlerts(set: Boolean) {
@@ -211,6 +219,7 @@ class AppPreferences {
     const val SETTING_PRIVACY_POLICY = "SETTING_PRIVACY_POLICY"
     const val SETTING_ROUND_TWO_DP = "SETTING_ROUND_TWO_DP"
     const val SETTING_NOTIFICATION_ALERTS = "SETTING_NOTIFICATION_ALERTS"
+    const val SETTING_INVERT_COLORS = "SETTING_INVERT_COLORS"
     const val WIDGET_BG = "WIDGET_BG"
     const val WIDGET_REFRESHING = "WIDGET_REFRESHING"
     const val TEXT_COLOR = "TEXT_COLOR"

--- a/app/src/main/kotlin/com/github/premnirmal/ticker/news/QuoteDetailActivity.kt
+++ b/app/src/main/kotlin/com/github/premnirmal/ticker/news/QuoteDetailActivity.kt
@@ -11,6 +11,7 @@ import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.github.mikephil.charting.charts.LineChart
+import com.github.premnirmal.ticker.AppPreferences
 import com.github.premnirmal.ticker.CustomTabs
 import com.github.premnirmal.ticker.analytics.ClickEvent
 import com.github.premnirmal.ticker.analytics.GeneralEvent
@@ -210,11 +211,39 @@ class QuoteDetailActivity : BaseGraphActivity(), NewsFeedAdapter.NewsClickListen
     val changeText = "${quote.changeStringWithSign()} ( ${quote.changePercentStringWithSign()})"
     change.text = changeText
     if (quote.change > 0 || quote.changeInPercent >= 0) {
-      change.setTextColor(ContextCompat.getColor(this, color.positive_green))
-      lastTradePrice.setTextColor(ContextCompat.getColor(this, color.positive_green))
+      change.setTextColor(ContextCompat.getColor(
+              this ,
+              if (!AppPreferences.INSTANCE.invertColors()) {
+                color.positive_green
+              } else {
+                color.negative_red
+              }
+      ))
+      lastTradePrice.setTextColor(ContextCompat.getColor(
+              this ,
+              if (!AppPreferences.INSTANCE.invertColors()) {
+                color.positive_green
+              } else {
+                color.negative_red
+              }
+      ))
     } else {
-      change.setTextColor(ContextCompat.getColor(this, color.negative_red))
-      lastTradePrice.setTextColor(ContextCompat.getColor(this, color.negative_red))
+      change.setTextColor(ContextCompat.getColor(
+              this ,
+              if (!AppPreferences.INSTANCE.invertColors()) {
+                color.negative_red
+              } else {
+                color.positive_green
+              }
+      ))
+      lastTradePrice.setTextColor(ContextCompat.getColor(
+              this ,
+              if (!AppPreferences.INSTANCE.invertColors()) {
+                color.negative_red
+              } else {
+                color.positive_green
+              }
+      ))
     }
     dividend.text = quote.dividendInfo()
     exchange.text = quote.stockExchange
@@ -360,18 +389,46 @@ class QuoteDetailActivity : BaseGraphActivity(), NewsFeedAdapter.NewsClickListen
         total_gain_loss.visibility = View.VISIBLE
         total_gain_loss.setText("${quote.gainLossString()} (${quote.gainLossPercentString()})")
         if (quote.gainLoss() >= 0) {
-          total_gain_loss.setTextColor(ContextCompat.getColor(this, color.positive_green))
+          total_gain_loss.setTextColor(ContextCompat.getColor(
+                  this ,
+                  if (!AppPreferences.INSTANCE.invertColors()) {
+                    color.positive_green
+                  } else {
+                    color.negative_red
+                  }
+          ))
         } else {
-          total_gain_loss.setTextColor(ContextCompat.getColor(this, color.negative_red))
+          total_gain_loss.setTextColor(ContextCompat.getColor(
+                  this ,
+                  if (!AppPreferences.INSTANCE.invertColors()) {
+                    color.negative_red
+                  } else {
+                    color.positive_green
+                  }
+          ))
         }
         average_price.visibility = View.VISIBLE
         average_price.setText(quote.averagePositionPrice())
         day_change.visibility = View.VISIBLE
         day_change.setText(quote.dayChangeString())
         if (quote.change > 0 || quote.changeInPercent >= 0) {
-          day_change.setTextColor(ContextCompat.getColor(this, color.positive_green))
+          day_change.setTextColor(ContextCompat.getColor(
+                  this ,
+                  if (!AppPreferences.INSTANCE.invertColors()) {
+                    color.positive_green
+                  } else {
+                    color.negative_red
+                  }
+          ))
         } else {
-          day_change.setTextColor(ContextCompat.getColor(this, color.negative_red))
+          day_change.setTextColor(ContextCompat.getColor(
+                  this ,
+                  if (!AppPreferences.INSTANCE.invertColors()) {
+                    color.negative_red
+                  } else {
+                    color.positive_green
+                  }
+          ))
         }
       } else {
         total_gain_loss.visibility = View.GONE

--- a/app/src/main/kotlin/com/github/premnirmal/ticker/portfolio/PortfolioVH.kt
+++ b/app/src/main/kotlin/com/github/premnirmal/ticker/portfolio/PortfolioVH.kt
@@ -4,6 +4,7 @@ import android.view.View
 import android.widget.TextView
 import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.RecyclerView
+import com.github.premnirmal.ticker.AppPreferences
 import com.github.premnirmal.ticker.network.data.Quote
 import com.github.premnirmal.ticker.portfolio.drag_drop.ItemTouchHelperViewHolder
 import com.github.premnirmal.ticker.ui.StockFieldView
@@ -16,8 +17,22 @@ import com.github.premnirmal.tickerwidget.R.color
 abstract class PortfolioVH(itemView: View) :
     RecyclerView.ViewHolder(itemView), ItemTouchHelperViewHolder {
 
-  protected val positiveColor: Int = ContextCompat.getColor(itemView.context, color.positive_green)
-  protected val negativeColor: Int = ContextCompat.getColor(itemView.context, color.negative_red)
+  protected val positiveColor: Int = ContextCompat.getColor(
+          itemView.context ,
+          if (!AppPreferences.INSTANCE.invertColors()) {
+            color.positive_green
+          } else {
+            color.negative_red
+          }
+  )
+  protected val negativeColor: Int = ContextCompat.getColor(
+          itemView.context ,
+          if (!AppPreferences.INSTANCE.invertColors()) {
+            color.negative_red
+          } else {
+            color.positive_green
+          }
+  )
   protected val neutralColor: Int = ContextCompat.getColor(itemView.context, color.text_1)
 
   @Throws(Exception::class) protected abstract fun updateView(quote: Quote, color: Int)

--- a/app/src/main/kotlin/com/github/premnirmal/ticker/settings/SettingsFragment.kt
+++ b/app/src/main/kotlin/com/github/premnirmal/ticker/settings/SettingsFragment.kt
@@ -407,6 +407,16 @@ class SettingsFragment : PreferenceFragmentCompat(), ChildFragment,
     }
 
     run {
+      val invertColorsPref = findPreference<CheckBoxPreference>(AppPreferences.SETTING_INVERT_COLORS)
+      invertColorsPref.isChecked = appPreferences.invertColors()
+      invertColorsPref.onPreferenceChangeListener =
+              Preference.OnPreferenceChangeListener { _, newValue ->
+                appPreferences.setInvertColors(newValue as Boolean)
+                true
+              }
+    }
+
+    run {
       val notifPref = findPreference<CheckBoxPreference>(AppPreferences.SETTING_NOTIFICATION_ALERTS)
       notifPref.isChecked = appPreferences.notificationAlerts()
       notifPref.onPreferenceChangeListener =

--- a/app/src/main/kotlin/com/github/premnirmal/ticker/widget/RemoteStockViewAdapter.kt
+++ b/app/src/main/kotlin/com/github/premnirmal/ticker/widget/RemoteStockViewAdapter.kt
@@ -111,9 +111,23 @@ class RemoteStockViewAdapter(private val widgetId: Int) : RemoteViewsService.Rem
 
       val color: Int
       color = if (change < 0f || changeInPercent < 0f) {
-        ContextCompat.getColor(context, widgetData.negativeTextColor)
+        ContextCompat.getColor(
+                context ,
+                if (!AppPreferences.INSTANCE.invertColors()) {
+                  widgetData.negativeTextColor
+                } else {
+                  widgetData.positiveTextColor
+                }
+        )
       } else {
-        ContextCompat.getColor(context, widgetData.positiveTextColor)
+        ContextCompat.getColor(
+                context ,
+                if (!AppPreferences.INSTANCE.invertColors()) {
+                  widgetData.positiveTextColor
+                } else {
+                  widgetData.negativeTextColor
+                }
+        )
       }
       if (stockViewLayout == R.layout.stockview3) {
         remoteViews.setTextColor(R.id.change, color)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -191,4 +191,6 @@
   <string name="error">Error</string>
   <string name="error_fetching_whats_new">Error fetching what\'s new</string>
   <string name="loading">Loading</string>
+  <string name="invert_colors">Invert font color</string>
+  <string name="invert_colors_desc">Invert gain/loss colors. Decrease in price will appear in green and a rise in price in red</string>
 </resources>

--- a/app/src/main/res/xml/prefs.xml
+++ b/app/src/main/res/xml/prefs.xml
@@ -91,6 +91,14 @@
       app:title="@string/round_two_dp"
       />
 
+  <CheckBoxPreference
+      app:key="SETTING_INVERT_COLORS"
+      app:selectable="true"
+      app:iconSpaceReserved="false"
+      app:summary="@string/invert_colors_desc"
+      app:title="@string/invert_colors"
+      />
+
   <Preference
       app:iconSpaceReserved="false"
       app:key="SETTING_SHARE"


### PR DESCRIPTION
Hi,

I added the settings to change the font color for the positive and negative value since the issue #170 was mentioned.
I learned that in most countries, the color are reversed, thank you @EdwinKuo for this lesson :)

![StockTicker_color_settings](https://user-images.githubusercontent.com/23734573/102695358-a9ca6d80-421e-11eb-8a08-cd3cd7548d50.png)

![StockTicker_color_inverse](https://user-images.githubusercontent.com/23734573/102695360-aafb9a80-421e-11eb-8417-50bb301881f1.png)

_I think that the code can be more efficient because I reuse the same if statement but with the color reversed._