### PR TITLE
Do not request permission on Android 13+.

### DIFF
--- a/app/src/main/kotlin/com/github/premnirmal/ticker/settings/SettingsFragment.kt
+++ b/app/src/main/kotlin/com/github/premnirmal/ticker/settings/SettingsFragment.kt
@@ -422,6 +422,9 @@ class SettingsFragment : PreferenceFragmentCompat(), ChildFragment,
   }
 
   private fun needsPermissionGrant(): Boolean {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+      return false;
+    }
     return Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && ContextCompat.checkSelfPermission(
         requireActivity(),
         Manifest.permission.WRITE_EXTERNAL_STORAGE

--- a/app/src/main/kotlin/com/github/premnirmal/ticker/settings/SettingsFragment.kt
+++ b/app/src/main/kotlin/com/github/premnirmal/ticker/settings/SettingsFragment.kt
@@ -423,7 +423,7 @@ class SettingsFragment : PreferenceFragmentCompat(), ChildFragment,
 
   private fun needsPermissionGrant(): Boolean {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-      return false;
+      return false
     }
     return Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && ContextCompat.checkSelfPermission(
         requireActivity(),


### PR DESCRIPTION
"On Android 13, we’re deprecating READ_EXTERNAL_STORAGE and WRITE_EXTERNAL_STORAGE permissions in favour of better alternative APIs for media file access."

If I understand the documentation correctly, this could actually stop requesting permissions on Android 10+, but does not cause an issue until Android 13.

https://medium.com/androiddevelopers/permissionless-is-the-future-of-storage-on-android-3fbceeb3d70a

Fixes #311.