### PR TITLE
Yahoo finance cookies and crumb

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -237,6 +237,7 @@ dependencies {
   implementation "com.squareup.retrofit2:retrofit:$RETROFIT_VERSION"
   implementation "com.squareup.retrofit2:converter-gson:$RETROFIT_VERSION"
   implementation "com.squareup.retrofit2:converter-simplexml:$RETROFIT_VERSION"
+  implementation "com.squareup.retrofit2:converter-scalars:$RETROFIT_VERSION"
   implementation "org.jsoup:jsoup:1.14.2"
 
   implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$COROUTINES_VERSION"

--- a/app/src/main/kotlin/com/github/premnirmal/ticker/AppPreferences.kt
+++ b/app/src/main/kotlin/com/github/premnirmal/ticker/AppPreferences.kt
@@ -2,7 +2,6 @@ package com.github.premnirmal.ticker
 
 import android.content.SharedPreferences
 import android.os.Build
-import androidx.annotation.VisibleForTesting
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.appcompat.app.AppCompatDelegate.NightMode
 import com.github.premnirmal.ticker.components.AppClock
@@ -22,7 +21,6 @@ import kotlin.random.Random
  */
 @Singleton
 class AppPreferences @Inject constructor(
-  @VisibleForTesting
   internal val sharedPreferences: SharedPreferences,
   private val clock: AppClock
 ) {
@@ -106,6 +104,14 @@ class AppPreferences @Inject constructor(
     sharedPreferences.edit()
         .putBoolean(WIDGET_REFRESHING, refreshing)
         .apply()
+  }
+
+  fun setCrumb(crumb: String?) {
+    sharedPreferences.edit().putString(CRUMB, crumb).apply()
+  }
+
+  fun getCrumb(): String? {
+    return sharedPreferences.getString(CRUMB, null)
   }
 
   fun tutorialShown(): Boolean {
@@ -217,7 +223,7 @@ class AppPreferences @Inject constructor(
     const val BOLD_CHANGE = "BOLD_CHANGE"
     const val SHOW_CURRENCY = "SHOW_CURRENCY"
     const val PERCENT = "PERCENT"
-    const val DID_RATE = "USER_DID_RATE"
+    const val CRUMB = "CRUMB"
     const val BACKOFF_ATTEMPTS = "BACKOFF_ATTEMPTS"
     const val APP_VERSION_CODE = "APP_VERSION_CODE"
     const val APP_THEME = "APP_THEME"

--- a/app/src/main/kotlin/com/github/premnirmal/ticker/network/CrumbInterceptor.kt
+++ b/app/src/main/kotlin/com/github/premnirmal/ticker/network/CrumbInterceptor.kt
@@ -17,12 +17,10 @@ class CrumbInterceptor @Inject constructor(
     val builder = chain.request().newBuilder()
     builder
       .removeHeader("Accept")
-      .removeHeader("Accept-Encoding")
       .addHeader(
         "Accept",
         "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7"
       )
-      .addHeader("Accept-Encoding", "gzip, deflate, br")
     if (!crumb.isNullOrEmpty()) {
       builder
         .url(chain.request().url.newBuilder().addQueryParameter("crumb", crumb).build())

--- a/app/src/main/kotlin/com/github/premnirmal/ticker/network/CrumbInterceptor.kt
+++ b/app/src/main/kotlin/com/github/premnirmal/ticker/network/CrumbInterceptor.kt
@@ -1,0 +1,34 @@
+package com.github.premnirmal.ticker.network
+
+import com.github.premnirmal.ticker.AppPreferences
+import okhttp3.Interceptor
+import okhttp3.Interceptor.Chain
+import okhttp3.Response
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class CrumbInterceptor @Inject constructor(
+  private val appPreferences: AppPreferences
+) : Interceptor {
+
+  override fun intercept(chain: Chain): Response {
+    val crumb = appPreferences.getCrumb()
+    val builder = chain.request().newBuilder()
+    builder
+      .removeHeader("Accept")
+      .removeHeader("Accept-Encoding")
+      .addHeader(
+        "Accept",
+        "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7"
+      )
+      .addHeader("Accept-Encoding", "gzip, deflate, br")
+    if (!crumb.isNullOrEmpty()) {
+      builder
+        .url(chain.request().url.newBuilder().addQueryParameter("crumb", crumb).build())
+    }
+    return chain.proceed(
+      builder.build()
+    )
+  }
+}

--- a/app/src/main/kotlin/com/github/premnirmal/ticker/network/NetworkModule.kt
+++ b/app/src/main/kotlin/com/github/premnirmal/ticker/network/NetworkModule.kt
@@ -1,7 +1,6 @@
 package com.github.premnirmal.ticker.network
 
 import android.content.Context
-import com.github.premnirmal.ticker.AppPreferences
 import com.github.premnirmal.tickerwidget.BuildConfig
 import com.github.premnirmal.tickerwidget.R
 import com.google.gson.Gson
@@ -17,8 +16,6 @@ import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 import retrofit2.converter.scalars.ScalarsConverterFactory
 import retrofit2.converter.simplexml.SimpleXmlConverterFactory
-import java.net.CookieHandler
-import java.net.CookieManager
 import java.util.concurrent.TimeUnit
 import javax.inject.Named
 import javax.inject.Singleton
@@ -120,8 +117,6 @@ class NetworkModule {
             .newBuilder()
             .removeHeader("Accept")
             .addHeader("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8")
-            .removeHeader("Accept-Encoding")
-            .addHeader("Accept-Encoding", "gzip, deflate, br")
             .build()
           chain.proceed(newRequest)
         }
@@ -147,8 +142,6 @@ class NetworkModule {
             .newBuilder()
             .removeHeader("Accept")
             .addHeader("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8")
-            .removeHeader("Accept-Encoding")
-            .addHeader("Accept-Encoding", "gzip, deflate, br")
             .build()
           chain.proceed(newRequest)
         }

--- a/app/src/main/kotlin/com/github/premnirmal/ticker/network/StocksApi.kt
+++ b/app/src/main/kotlin/com/github/premnirmal/ticker/network/StocksApi.kt
@@ -22,8 +22,8 @@ import javax.inject.Singleton
  */
 @Singleton
 class StocksApi @Inject constructor(
-  private val gson: Gson,
   private val yahooFinanceInitialLoad: YahooFinanceInitialLoad,
+  private val yahooFinanceCrumb: YahooFinanceCrumb,
   private val yahooFinance: YahooFinance,
   private val coroutineScope: CoroutineScope,
   private val appPreferences: AppPreferences,
@@ -43,12 +43,8 @@ class StocksApi @Inject constructor(
   private suspend fun loadCrumb() {
     withContext(Dispatchers.IO) {
       try {
-        val initialLoad = yahooFinanceInitialLoad.initialLoad()
-        if (!initialLoad.isSuccessful) {
-          Timber.e("Failed initial load with code: ${initialLoad.code()}")
-          return@withContext
-        }
-        val crumbResponse = yahooFinance.getCrumb()
+        yahooFinanceInitialLoad.initialLoad()
+        val crumbResponse = yahooFinanceCrumb.getCrumb()
         if (crumbResponse.isSuccessful) {
           val crumb = crumbResponse.body()
           if (!crumb.isNullOrEmpty()) {

--- a/app/src/main/kotlin/com/github/premnirmal/ticker/network/StocksApi.kt
+++ b/app/src/main/kotlin/com/github/premnirmal/ticker/network/StocksApi.kt
@@ -39,12 +39,6 @@ class StocksApi @Inject constructor(
     Regex("csrfToken\" value=\"(.+)\">")
   }
 
-  init {
-    coroutineScope.launch {
-      loadCrumb()
-    }
-  }
-
   private suspend fun loadCrumb() { withContext(Dispatchers.IO) {
       try {
         val initialLoad = yahooFinanceInitialLoad.initialLoad()

--- a/app/src/main/kotlin/com/github/premnirmal/ticker/network/UserAgentInterceptor.kt
+++ b/app/src/main/kotlin/com/github/premnirmal/ticker/network/UserAgentInterceptor.kt
@@ -3,16 +3,19 @@ package com.github.premnirmal.ticker.network
 import android.content.Context
 import android.os.Build
 import com.github.premnirmal.tickerwidget.BuildConfig
+import dagger.hilt.android.qualifiers.ApplicationContext
 import okhttp3.Interceptor
 import okhttp3.Interceptor.Chain
 import okhttp3.Response
 import java.io.IOException
+import javax.inject.Inject
+import javax.inject.Singleton
 
-class UserAgentInterceptor(private val context: Context) : Interceptor {
+@Singleton
+class UserAgentInterceptor @Inject constructor(@ApplicationContext private val context: Context) : Interceptor {
 
   companion object {
     private const val USER_AGENT_FORMAT = "%s/%s(%s) (Android %s; %s %s)"
-    private const val USER_AGENT_KEY = "UserAgent"
   }
 
   private val userAgent by lazy {
@@ -31,7 +34,8 @@ class UserAgentInterceptor(private val context: Context) : Interceptor {
   @Throws(IOException::class) override fun intercept(chain: Chain): Response {
     val newRequest = chain.request()
         .newBuilder()
-        .addHeader(USER_AGENT_KEY, userAgent)
+        .removeHeader("User-Agent")
+        .addHeader("User-Agent", userAgent)
         .build()
     return chain.proceed(newRequest)
   }

--- a/app/src/main/kotlin/com/github/premnirmal/ticker/network/YahooFinance.kt
+++ b/app/src/main/kotlin/com/github/premnirmal/ticker/network/YahooFinance.kt
@@ -21,15 +21,17 @@ interface YahooFinance {
     "v7/finance/quote?format=json"
   )
   suspend fun getStocks(@Query(value = "symbols") query: String): Response<YahooResponse>
+}
+interface YahooFinanceInitialLoad {
+  @GET("/")
+  suspend fun initialLoad()
+}
+interface YahooFinanceCrumb {
 
   @GET(
     "v1/test/getcrumb"
   )
   suspend fun getCrumb(): Response<String>
-}
-interface YahooFinanceInitialLoad {
-  @GET("/")
-  suspend fun initialLoad(): Response<String?>
 }
 
 interface YahooQuoteDetails {

--- a/app/src/main/kotlin/com/github/premnirmal/ticker/network/YahooFinance.kt
+++ b/app/src/main/kotlin/com/github/premnirmal/ticker/network/YahooFinance.kt
@@ -2,7 +2,9 @@ package com.github.premnirmal.ticker.network
 
 import com.github.premnirmal.ticker.network.data.AssetDetailsResponse
 import com.github.premnirmal.ticker.network.data.YahooResponse
+import retrofit2.Response
 import retrofit2.http.GET
+import retrofit2.http.Header
 import retrofit2.http.Path
 import retrofit2.http.Query
 
@@ -16,9 +18,18 @@ interface YahooFinance {
    * @return A List of quotes.
    */
   @GET(
-      "quote?format=json"
+    "v7/finance/quote?format=json"
   )
-  suspend fun getStocks(@Query(value = "symbols") query: String): YahooResponse
+  suspend fun getStocks(@Query(value = "symbols") query: String): Response<YahooResponse>
+
+  @GET(
+    "v1/test/getcrumb"
+  )
+  suspend fun getCrumb(): Response<String>
+}
+interface YahooFinanceInitialLoad {
+  @GET("/")
+  suspend fun initialLoad(): Response<String?>
 }
 
 interface YahooQuoteDetails {

--- a/app/src/main/kotlin/com/github/premnirmal/ticker/network/YahooFinance.kt
+++ b/app/src/main/kotlin/com/github/premnirmal/ticker/network/YahooFinance.kt
@@ -6,7 +6,6 @@ import okhttp3.RequestBody
 import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.GET
-import retrofit2.http.Header
 import retrofit2.http.POST
 import retrofit2.http.Path
 import retrofit2.http.Query
@@ -30,7 +29,7 @@ interface YahooFinanceInitialLoad {
   @GET("/")
   suspend fun initialLoad(): Response<String?>
 
-  @POST("/")
+  @POST
   suspend fun cookieConsent(@Url url: String?, @Body body: RequestBody): Response<String?>
 }
 interface YahooFinanceCrumb {

--- a/app/src/main/kotlin/com/github/premnirmal/ticker/network/YahooFinance.kt
+++ b/app/src/main/kotlin/com/github/premnirmal/ticker/network/YahooFinance.kt
@@ -2,11 +2,15 @@ package com.github.premnirmal.ticker.network
 
 import com.github.premnirmal.ticker.network.data.AssetDetailsResponse
 import com.github.premnirmal.ticker.network.data.YahooResponse
+import okhttp3.RequestBody
 import retrofit2.Response
+import retrofit2.http.Body
 import retrofit2.http.GET
 import retrofit2.http.Header
+import retrofit2.http.POST
 import retrofit2.http.Path
 import retrofit2.http.Query
+import retrofit2.http.Url
 
 interface YahooFinance {
 
@@ -24,7 +28,10 @@ interface YahooFinance {
 }
 interface YahooFinanceInitialLoad {
   @GET("/")
-  suspend fun initialLoad()
+  suspend fun initialLoad(): Response<String?>
+
+  @POST("/")
+  suspend fun cookieConsent(@Url url: String?, @Body body: RequestBody): Response<String?>
 }
 interface YahooFinanceCrumb {
 

--- a/app/src/main/kotlin/com/github/premnirmal/ticker/network/YahooFinanceCookies.kt
+++ b/app/src/main/kotlin/com/github/premnirmal/ticker/network/YahooFinanceCookies.kt
@@ -1,0 +1,24 @@
+package com.github.premnirmal.ticker.network
+
+import okhttp3.Cookie
+import okhttp3.CookieJar
+import okhttp3.HttpUrl
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class YahooFinanceCookies @Inject constructor() : CookieJar {
+
+  private val _cookies = ArrayList<Cookie>()
+
+  override fun saveFromResponse(url: HttpUrl, cookies: List<Cookie>) {
+    if (url.toString().equals("https://finance.yahoo.com/", true)) {
+      _cookies.clear()
+    }
+    _cookies.addAll(cookies)
+  }
+
+  override fun loadForRequest(url: HttpUrl): List<Cookie> {
+    return _cookies
+  }
+}

--- a/app/src/main/kotlin/com/github/premnirmal/ticker/network/YahooFinanceCookies.kt
+++ b/app/src/main/kotlin/com/github/premnirmal/ticker/network/YahooFinanceCookies.kt
@@ -9,13 +9,15 @@ import javax.inject.Singleton
 @Singleton
 class YahooFinanceCookies @Inject constructor() : CookieJar {
 
-  private var _cookies = emptyList<Cookie>()
+  private var _cookies = HashMap<String, Cookie>()
 
   override fun saveFromResponse(url: HttpUrl, cookies: List<Cookie>) {
-    _cookies = cookies
+    cookies.forEach { cookie ->
+      _cookies[cookie.name] = cookie
+    }
   }
 
   override fun loadForRequest(url: HttpUrl): List<Cookie> {
-     return _cookies
+    return _cookies.values.toList()
   }
 }

--- a/app/src/main/kotlin/com/github/premnirmal/ticker/network/YahooFinanceCookies.kt
+++ b/app/src/main/kotlin/com/github/premnirmal/ticker/network/YahooFinanceCookies.kt
@@ -9,16 +9,13 @@ import javax.inject.Singleton
 @Singleton
 class YahooFinanceCookies @Inject constructor() : CookieJar {
 
-  private val _cookies = ArrayList<Cookie>()
+  private var _cookies = emptyList<Cookie>()
 
   override fun saveFromResponse(url: HttpUrl, cookies: List<Cookie>) {
-    if (url.toString().equals("https://finance.yahoo.com/", true)) {
-      _cookies.clear()
-    }
-    _cookies.addAll(cookies)
+    _cookies = cookies
   }
 
   override fun loadForRequest(url: HttpUrl): List<Cookie> {
-    return _cookies
+     return _cookies
   }
 }

--- a/app/src/main/kotlin/com/github/premnirmal/ticker/news/TrendingAdapter.kt
+++ b/app/src/main/kotlin/com/github/premnirmal/ticker/news/TrendingAdapter.kt
@@ -81,6 +81,9 @@ class TrendingStocksVH(binding: ItemTrendingStocksBinding) : TrendingVH<ItemTren
     listener: TrendingListener
   ) {
     val quotes = (item as TrendingStockNewsFeed).quotes
+    if (quotes.isEmpty()) {
+      return
+    }
     when (quotes.size) {
       1 -> {
         binding.stock2.root.isVisible = false

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6,7 +6,8 @@
   <string name="yahoo_news_endpoint" translatable="false">https://finance.yahoo.com/news/</string>
   <string name="yahoo_finance_endpoint" translatable="false">https://finance.yahoo.com/</string>
   <string name="suggestions_endpoint" translatable="false">https://query2.finance.yahoo.com/v1/finance/</string>
-  <string name="yahoo_endpoint" translatable="false">https://query1.finance.yahoo.com/v6/finance/</string>
+  <string name="yahoo_endpoint" translatable="false">https://query1.finance.yahoo.com/</string>
+  <string name="yahoo_initial_load_endpoint" translatable="false">https://finance.yahoo.com/</string>
   <string name="yahoo_endpoint_quote_details" translatable="false">https://query1.finance.yahoo.com/v11/finance/</string>
   <string name="historical_data_endpoint" translatable="false">https://query1.finance.yahoo.com/v8/finance/</string>
   <string name="github_endoint" translatable="false">https://api.github.com/</string>

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,19 +1,18 @@
-# Project-wide Gradle settings.
-# IDE (e.g. Android Studio) users:
-# Gradle settings configured through the IDE *will override*
-# any settings specified in this file.
-# For more details on how to configure your build environment visit
+## For more details on how to configure your build environment visit
 # http://www.gradle.org/docs/current/userguide/build_environment.html
+#
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-# Default value: -Xmx10248m -XX:MaxPermSize=256m
+# Default value: -Xmx1024m -XX:MaxPermSize=256m
 # org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+#
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
-org.gradle.jvmargs=-Xmx2560m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
-org.gradle.caching=true
-android.useAndroidX=true
+#Sat May 06 12:58:51 BST 2023
 android.enableJetifier=true
 android.nonTransitiveRClass=true
+android.useAndroidX=true
+org.gradle.caching=true
+org.gradle.jvmargs=-Xmx1536M -Dkotlin.daemon.jvm.options\="-Xmx1024M" -XX\:MaxPermSize\=512m -XX\:+HeapDumpOnOutOfMemoryError -Dfile.encoding\=UTF-8


### PR DESCRIPTION
Attemptint to fix #330 by saving cookies on response and retrieving the crumb from yahoo finance. Steps are:

1. Perform GET to `https://finance.yahoo.com`, expect a set-cookie with 3 cookies for this session.This works from the browser and from postman, but not on android - needs fixing
2. Perform GET to `https://query1.finance.yahoo.com/v1/test/getcrumb` with the cookies from (1) to retrieve a crumb
3. Add crumb query param to requests to retrieve quotes

(1) still needs fixing, needs help