### PR TITLE
Fix windows build

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -44,7 +44,7 @@ def getOldGitVersion = { ->
   def stdout = new ByteArrayOutputStream()
   exec {
     if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-      commandLine 'cmd', '/c', 'Powershell', "git tag --sort=-committerdate | Select-Object -first 10 | Select-Object -last 1"
+      commandLine 'powershell', '-command', "& {git tag --sort=-committerdate | Select-Object -first 10 | Select-Object -last 1}"
     } else {
       commandLine 'sh', '-c', "git tag --sort=-committerdate | head -10 | tail -1"
     }


### PR DESCRIPTION
getOldGitVersion was failing on Windows because of incorrect powershell invocation.