### PR TITLE
Clarify translation

### DIFF
--- a/app/src/main/res/values-de/settings.xml
+++ b/app/src/main/res/values-de/settings.xml
@@ -23,7 +23,7 @@
 
   <string-array name="widget_width_types">
     <item>Standard</item>
-    <item>Einzeilig darstellen</item>
+    <item>Eine Aktie pro Zeile</item>
   </string-array>
 
   <string-array name="backgrounds">


### PR DESCRIPTION
The German translation here was unspecific. I tells the user, that it is shown in one row and not one stock per row. So you might think of all stocks in one row, when you read it.

@premnirmal I also recognized some missing translation for German, my native language. How could I add all missing translations for that language? Is there some tool to add all missing XML keys, so that I only have to fill them with the translations?