### PR TITLE
New Feature: Custom Display Name 

### DIFF
--- a/app/schemas/com.github.premnirmal.ticker.repo.QuotesDB/8.json
+++ b/app/schemas/com.github.premnirmal.ticker.repo.QuotesDB/8.json
@@ -1,0 +1,296 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 8,
+    "identityHash": "735379878be3483b838d3b2379002c6b",
+    "entities": [
+      {
+        "tableName": "QuoteRow",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`symbol` TEXT NOT NULL, `name` TEXT NOT NULL, `last_trade_price` REAL NOT NULL, `change_percent` REAL NOT NULL, `change` REAL NOT NULL, `exchange` TEXT NOT NULL, `currency` TEXT NOT NULL, `is_post_market` INTEGER NOT NULL, `annual_dividend_rate` REAL NOT NULL, `annual_dividend_yield` REAL NOT NULL, `dayHigh` REAL, `dayLow` REAL, `previousClose` REAL NOT NULL, `open` REAL, `regularMarketVolume` REAL, `peRatio` REAL, `fiftyTwoWeekLowChange` REAL, `fiftyTwoWeekLowChangePercent` REAL, `fiftyTwoWeekHighChange` REAL, `fiftyTwoWeekHighChangePercent` REAL, `fiftyTwoWeekLow` REAL, `fiftyTwoWeekHigh` REAL, `dividendDate` REAL, `earningsDate` REAL, `marketCap` REAL, `isTradeable` INTEGER, `isTriggerable` INTEGER, `marketState` TEXT, `fiftyDayAverage` REAL, `twoHundredDayAverage` REAL, PRIMARY KEY(`symbol`))",
+        "fields": [
+          {
+            "fieldPath": "symbol",
+            "columnName": "symbol",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastTradePrice",
+            "columnName": "last_trade_price",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "changeInPercent",
+            "columnName": "change_percent",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "change",
+            "columnName": "change",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "stockExchange",
+            "columnName": "exchange",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currency",
+            "columnName": "currency",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isPostMarket",
+            "columnName": "is_post_market",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "annualDividendRate",
+            "columnName": "annual_dividend_rate",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "annualDividendYield",
+            "columnName": "annual_dividend_yield",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dayHigh",
+            "columnName": "dayHigh",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "dayLow",
+            "columnName": "dayLow",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "previousClose",
+            "columnName": "previousClose",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "open",
+            "columnName": "open",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "regularMarketVolume",
+            "columnName": "regularMarketVolume",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "peRatio",
+            "columnName": "peRatio",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "fiftyTwoWeekLowChange",
+            "columnName": "fiftyTwoWeekLowChange",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "fiftyTwoWeekLowChangePercent",
+            "columnName": "fiftyTwoWeekLowChangePercent",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "fiftyTwoWeekHighChange",
+            "columnName": "fiftyTwoWeekHighChange",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "fiftyTwoWeekHighChangePercent",
+            "columnName": "fiftyTwoWeekHighChangePercent",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "fiftyTwoWeekLow",
+            "columnName": "fiftyTwoWeekLow",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "fiftyTwoWeekHigh",
+            "columnName": "fiftyTwoWeekHigh",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "dividendDate",
+            "columnName": "dividendDate",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "earningsDate",
+            "columnName": "earningsDate",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "marketCap",
+            "columnName": "marketCap",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "isTradeable",
+            "columnName": "isTradeable",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "isTriggerable",
+            "columnName": "isTriggerable",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "marketState",
+            "columnName": "marketState",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "fiftyDayAverage",
+            "columnName": "fiftyDayAverage",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "twoHundredDayAverage",
+            "columnName": "twoHundredDayAverage",
+            "affinity": "REAL",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "symbol"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "HoldingRow",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT, `quote_symbol` TEXT NOT NULL, `shares` REAL NOT NULL, `price` REAL NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "quoteSymbol",
+            "columnName": "quote_symbol",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "shares",
+            "columnName": "shares",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "price",
+            "columnName": "price",
+            "affinity": "REAL",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "PropertiesRow",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT, `properties_quote_symbol` TEXT NOT NULL, `notes` TEXT NOT NULL, `displayname` TEXT NOT NULL, `alert_above` REAL NOT NULL, `alert_below` REAL NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "quoteSymbol",
+            "columnName": "properties_quote_symbol",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notes",
+            "columnName": "notes",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayname",
+            "columnName": "displayname",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "alertAbove",
+            "columnName": "alert_above",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "alertBelow",
+            "columnName": "alert_below",
+            "affinity": "REAL",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '735379878be3483b838d3b2379002c6b')"
+    ]
+  }
+}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -42,6 +42,11 @@
             android:theme="@style/AddPositionTheme"
             android:windowSoftInputMode="adjustResize" />
         <activity
+            android:name="com.github.premnirmal.ticker.portfolio.AddDisplaynameActivity"
+            android:label="@string/add_displayname"
+            android:theme="@style/AddPositionTheme"
+            android:windowSoftInputMode="adjustResize" />
+        <activity
             android:name="com.github.premnirmal.ticker.portfolio.AddAlertsActivity"
             android:label="@string/add_alerts"
             android:theme="@style/AddPositionTheme"

--- a/app/src/main/kotlin/com/github/premnirmal/ticker/components/AppModule.kt
+++ b/app/src/main/kotlin/com/github/premnirmal/ticker/components/AppModule.kt
@@ -21,6 +21,7 @@ import com.github.premnirmal.ticker.repo.migrations.MIGRATION_3_4
 import com.github.premnirmal.ticker.repo.migrations.MIGRATION_4_5
 import com.github.premnirmal.ticker.repo.migrations.MIGRATION_5_6
 import com.github.premnirmal.ticker.repo.migrations.MIGRATION_6_7
+import com.github.premnirmal.ticker.repo.migrations.MIGRATION_7_8
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -66,6 +67,7 @@ class AppModule {
         .addMigrations(MIGRATION_4_5)
         .addMigrations(MIGRATION_5_6)
         .addMigrations(MIGRATION_6_7)
+        .addMigrations(MIGRATION_7_8)
         .build()
   }
 

--- a/app/src/main/kotlin/com/github/premnirmal/ticker/network/data/Properties.kt
+++ b/app/src/main/kotlin/com/github/premnirmal/ticker/network/data/Properties.kt
@@ -7,6 +7,7 @@ import kotlinx.android.parcel.Parcelize
 data class Properties(
   val symbol: String,
   var notes: String = "",
+  var displayname: String = "",
   var alertAbove: Float = 0.0f,
   var alertBelow: Float = 0.0f,
   var id: Long? = null

--- a/app/src/main/kotlin/com/github/premnirmal/ticker/news/QuoteDetailActivity.kt
+++ b/app/src/main/kotlin/com/github/premnirmal/ticker/news/QuoteDetailActivity.kt
@@ -35,6 +35,7 @@ import com.github.premnirmal.ticker.network.data.QuoteSummary
 import com.github.premnirmal.ticker.news.NewsFeedItem.ArticleNewsFeed
 import com.github.premnirmal.ticker.portfolio.AddAlertsActivity
 import com.github.premnirmal.ticker.portfolio.AddNotesActivity
+import com.github.premnirmal.ticker.portfolio.AddDisplaynameActivity
 import com.github.premnirmal.ticker.portfolio.AddPositionActivity
 import com.github.premnirmal.ticker.showDialog
 import com.github.premnirmal.ticker.ui.SpacingDecoration
@@ -56,6 +57,7 @@ class QuoteDetailActivity : BaseGraphActivity<ActivityQuoteDetailBinding>(), Tre
     private const val REQ_EDIT_POSITIONS = 10001
     private const val REQ_EDIT_NOTES = 10002
     private const val REQ_EDIT_ALERTS = 10003
+    private const val REQ_EDIT_DISPLAYNAME = 10004
     private const val INDEX_PROGRESS = 0
     private const val INDEX_ERROR = 1
     private const val INDEX_EMPTY = 2
@@ -200,6 +202,13 @@ class QuoteDetailActivity : BaseGraphActivity<ActivityQuoteDetailBinding>(), Tre
       notesOnClickListener()
     }
 
+    binding.displaynameHeader.setOnClickListener {
+      displaynameOnClickListener()
+    }
+    binding.displaynameContainer.setOnClickListener {
+      displaynameOnClickListener()
+    }
+
     binding.alertHeader.setOnClickListener {
       alertsOnClickListener()
     }
@@ -292,6 +301,15 @@ class QuoteDetailActivity : BaseGraphActivity<ActivityQuoteDetailBinding>(), Tre
     startActivityForResult(intent, REQ_EDIT_NOTES)
   }
 
+  private fun displaynameOnClickListener() {
+    analytics.trackClickEvent(
+        ClickEvent("EditDisplaynameClick")
+    )
+    val intent = Intent(this, AddDisplaynameActivity::class.java)
+    intent.putExtra(AddDisplaynameActivity.TICKER, quote.symbol)
+    startActivityForResult(intent, REQ_EDIT_DISPLAYNAME)
+  }
+
   private fun alertsOnClickListener() {
     analytics.trackClickEvent(
         ClickEvent("EditAlertsClick")
@@ -333,6 +351,11 @@ class QuoteDetailActivity : BaseGraphActivity<ActivityQuoteDetailBinding>(), Tre
         viewModel.loadQuote(ticker)
       }
     }
+    if (requestCode == REQ_EDIT_DISPLAYNAME) {
+      if (resultCode == Activity.RESULT_OK) {
+        viewModel.loadQuote(ticker)
+      }
+    }
     super.onActivityResult(requestCode, resultCode, data)
   }
 
@@ -363,6 +386,8 @@ class QuoteDetailActivity : BaseGraphActivity<ActivityQuoteDetailBinding>(), Tre
       binding.positionsHeader.visibility = View.VISIBLE
       binding.notesHeader.visibility = View.VISIBLE
       binding.notesContainer.visibility = View.VISIBLE
+      binding.displaynameHeader.visibility = View.VISIBLE
+      binding.displaynameContainer.visibility = View.VISIBLE
       binding.alertHeader.visibility = View.VISIBLE
       binding.numShares.text = quote.numSharesString()
       binding.equityValue.text = quote.priceFormat.format(quote.holdings())
@@ -372,6 +397,13 @@ class QuoteDetailActivity : BaseGraphActivity<ActivityQuoteDetailBinding>(), Tre
         binding.notesDisplay.text = "--"
       } else {
         binding.notesDisplay.text = notesText
+      }
+      val displaynameText = quote.properties?.displayname
+      binding.displaynameContainer.visibility = View.VISIBLE
+      if (displaynameText.isNullOrEmpty()) {
+        binding.displaynameDisplay.text = quote.symbol
+      } else {
+        binding.displaynameDisplay.text = displaynameText
       }
       val alertAbove = quote.getAlertAbove()
       val alertBelow = quote.getAlertBelow()
@@ -420,6 +452,8 @@ class QuoteDetailActivity : BaseGraphActivity<ActivityQuoteDetailBinding>(), Tre
       binding.positionsContainer.visibility = View.GONE
       binding.notesHeader.visibility = View.GONE
       binding.notesContainer.visibility = View.GONE
+      binding.displaynameHeader.visibility = View.GONE
+      binding.displaynameContainer.visibility = View.GONE
       binding.alertHeader.visibility = View.GONE
       binding.alertsContainer.visibility = View.GONE
     }

--- a/app/src/main/kotlin/com/github/premnirmal/ticker/portfolio/AddDisplaynameActivity.kt
+++ b/app/src/main/kotlin/com/github/premnirmal/ticker/portfolio/AddDisplaynameActivity.kt
@@ -1,0 +1,69 @@
+package com.github.premnirmal.ticker.portfolio
+
+import android.app.Activity
+import android.content.Intent
+import android.os.Bundle
+import androidx.activity.viewModels
+import com.github.premnirmal.ticker.base.BaseActivity
+import com.github.premnirmal.ticker.components.InAppMessage
+import com.github.premnirmal.ticker.dismissKeyboard
+import com.github.premnirmal.ticker.viewBinding
+import com.github.premnirmal.tickerwidget.R
+import com.github.premnirmal.tickerwidget.databinding.ActivityDisplaynameBinding
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class AddDisplaynameActivity : BaseActivity<ActivityDisplaynameBinding>() {
+  override val binding: (ActivityDisplaynameBinding) by viewBinding(ActivityDisplaynameBinding::inflate)
+
+  companion object {
+    const val TICKER = "TICKER"
+  }
+
+  override val simpleName: String = "AddDisplaynameActivity"
+  internal lateinit var ticker: String
+  private val viewModel: DisplaynameViewModel by viewModels()
+
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    binding.toolbar.setNavigationOnClickListener {
+      finish()
+    }
+    binding.toolbar.setOnMenuItemClickListener {
+      onSaveClick()
+      true
+    }
+    if (intent.hasExtra(TICKER) && intent.getStringExtra(TICKER) != null) {
+      ticker = intent.getStringExtra(TICKER)!!
+    } else {
+      ticker = ""
+      InAppMessage.showToast(this, R.string.error_symbol)
+      finish()
+      return
+    }
+    binding.tickerName.text = ticker
+    viewModel.symbol = ticker
+    val quote = viewModel.quote
+    quote?.properties?.let {
+      binding.displaynameInputEditText.setText(it.displayname)
+    }
+  }
+
+  override fun onResume() {
+    super.onResume()
+    binding.displaynameInputEditText.requestFocus()
+  }
+
+  private fun onSaveClick() {
+    val displayname = binding.displaynameInputEditText.text.toString()
+    viewModel.setDisplayname(displayname)
+    updateActivityResult()
+    dismissKeyboard()
+    finish()
+  }
+
+  private fun updateActivityResult() {
+    val data = Intent()
+    setResult(Activity.RESULT_OK, data)
+  }
+}

--- a/app/src/main/kotlin/com/github/premnirmal/ticker/portfolio/DisplaynameViewModel.kt
+++ b/app/src/main/kotlin/com/github/premnirmal/ticker/portfolio/DisplaynameViewModel.kt
@@ -1,0 +1,35 @@
+package com.github.premnirmal.ticker.portfolio
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.github.premnirmal.ticker.model.StocksProvider
+import com.github.premnirmal.ticker.network.data.Properties
+import com.github.premnirmal.ticker.network.data.Quote
+import com.github.premnirmal.ticker.repo.StocksStorage
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class DisplaynameViewModel @Inject constructor(
+  private val stocksProvider: StocksProvider,
+  private val stocksStorage: StocksStorage
+) : ViewModel() {
+
+  lateinit var symbol: String
+  val quote: Quote?
+    get() = stocksProvider.getStock(symbol)
+
+  fun setDisplayname(displayname: String) {
+    viewModelScope.launch {
+      quote?.let {
+        val properties = it.properties ?: Properties(
+            symbol
+        )
+        it.properties = properties
+        properties.displayname = displayname
+        stocksStorage.saveQuoteProperties(properties)
+      }
+    }
+  }
+}

--- a/app/src/main/kotlin/com/github/premnirmal/ticker/repo/QuoteDao.kt
+++ b/app/src/main/kotlin/com/github/premnirmal/ticker/repo/QuoteDao.kt
@@ -89,7 +89,7 @@ interface QuoteDao {
     if (propertiesRow.quoteSymbol.isNotEmpty()) {
       deletePropertiesByQuoteId(propertiesRow.quoteSymbol)
     }
-    if (propertiesRow.notes.isNotEmpty() || propertiesRow.alertAbove > 0.0f || propertiesRow.alertBelow > 0.0f) {
+    if (propertiesRow.notes.isNotEmpty() || propertiesRow.displayname.isNotEmpty() || propertiesRow.alertAbove > 0.0f || propertiesRow.alertBelow > 0.0f) {
       insertProperties(propertiesRow)
     }
   }

--- a/app/src/main/kotlin/com/github/premnirmal/ticker/repo/QuotesDB.kt
+++ b/app/src/main/kotlin/com/github/premnirmal/ticker/repo/QuotesDB.kt
@@ -8,7 +8,7 @@ import com.github.premnirmal.ticker.repo.data.QuoteRow
 
 @Database(
     entities = [QuoteRow::class, HoldingRow::class, PropertiesRow::class],
-    version = 7,
+    version = 8,
     exportSchema = true
 )
 abstract class QuotesDB : RoomDatabase() {

--- a/app/src/main/kotlin/com/github/premnirmal/ticker/repo/StocksStorage.kt
+++ b/app/src/main/kotlin/com/github/premnirmal/ticker/repo/StocksStorage.kt
@@ -192,11 +192,12 @@ class StocksStorage @Inject constructor(
 
   private fun PropertiesRow.toProperties(): Properties {
     return Properties(
-        this.quoteSymbol, this.notes, this.alertAbove, this.alertBelow
+        this.quoteSymbol, this.notes, this.displayname, this.alertAbove, this.alertBelow
     )
   }
 
   private fun Properties.toPropertiesRow(): PropertiesRow {
-    return PropertiesRow(this.id, this.symbol, this.notes, this.alertAbove, this.alertBelow)
+    return PropertiesRow(this.id, this.symbol, this.notes, this.displayname, this.alertAbove, this.alertBelow)
   }
 }
+

--- a/app/src/main/kotlin/com/github/premnirmal/ticker/repo/data/PropertiesRow.kt
+++ b/app/src/main/kotlin/com/github/premnirmal/ticker/repo/data/PropertiesRow.kt
@@ -9,6 +9,7 @@ data class PropertiesRow(
   @PrimaryKey(autoGenerate = true) var id: Long? = null,
   @ColumnInfo(name = "properties_quote_symbol") val quoteSymbol: String,
   @ColumnInfo(name = "notes") val notes: String = "",
+  @ColumnInfo(name = "displayname") val displayname: String = "",
   @ColumnInfo(name = "alert_above") val alertAbove: Float = 0.0f,
   @ColumnInfo(name = "alert_below") val alertBelow: Float = 0.0f
 )

--- a/app/src/main/kotlin/com/github/premnirmal/ticker/repo/migrations/Migrations.kt
+++ b/app/src/main/kotlin/com/github/premnirmal/ticker/repo/migrations/Migrations.kt
@@ -104,3 +104,9 @@ val MIGRATION_6_7 = object : Migration(6, 7) {
     database.execSQL("ALTER TABLE `$tableName` ADD COLUMN `twoHundredDayAverage` REAL;")
   }
 }
+
+val MIGRATION_7_8 = object : Migration(7, 8) {
+  override fun migrate(database: SupportSQLiteDatabase) {
+    database.execSQL("ALTER TABLE PropertiesRow ADD COLUMN displayname TEXT NOT NULL DEFAULT ''")
+  }
+}

--- a/app/src/main/kotlin/com/github/premnirmal/ticker/widget/RemoteStockViewAdapter.kt
+++ b/app/src/main/kotlin/com/github/premnirmal/ticker/widget/RemoteStockViewAdapter.kt
@@ -82,7 +82,11 @@ class RemoteStockViewAdapter(private val widgetId: Int) : RemoteViewsService.Rem
       val gainLossPercentString = SpannableString(gainLossPercentFormatted)
       val priceString = SpannableString(priceFormatted)
 
-      remoteViews.setTextViewText(R.id.ticker, stock.symbol)
+      remoteViews.setTextViewText(R.id.ticker, stock.properties?.displayname
+        .takeUnless { it.isNullOrBlank() }
+        ?: stock.symbol
+      )
+
       remoteViews.setTextViewText(R.id.holdings, if (widgetData.isCurrencyEnabled()) {
         stock.priceFormat.format(stock.holdings())
       } else {

--- a/app/src/main/res/layout-land/activity_quote_detail.xml
+++ b/app/src/main/res/layout-land/activity_quote_detail.xml
@@ -507,6 +507,58 @@
 
         </LinearLayout>
 
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:id="@+id/displayname_header"
+            android:layout_marginBottom="8dp"
+            android:layout_marginEnd="16dp"
+            android:layout_marginStart="16dp"
+            android:layout_marginTop="8dp"
+            android:orientation="horizontal"
+            >
+
+          <TextView
+              android:layout_width="0dp"
+              android:layout_height="wrap_content"
+              android:layout_gravity="center_vertical"
+              android:layout_weight="1"
+              android:gravity="center_vertical"
+              android:text="@string/displayname"
+              style="@style/Widget.StocksWidget.TextView.LabelMedium"
+      android:textAppearance="@style/TextAppearance.StocksWidget.LabelMedium"
+            />
+
+          <ImageView
+              android:id="@+id/edit_displayname"
+              android:layout_width="20dp"
+              android:layout_height="20dp"
+              android:src="@drawable/ic_edit"
+              />
+
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:id="@+id/displayname_container"
+            android:visibility="gone"
+            android:layout_margin="8dp"
+            android:orientation="vertical"
+            >
+
+          <TextView
+              android:id="@+id/displayname_display"
+              android:layout_width="match_parent"
+              android:layout_height="wrap_content"
+              android:layout_marginStart="8dp"
+              android:layout_marginLeft="8dp"
+              android:layout_marginEnd="8dp"
+              android:layout_marginRight="8dp"
+              />
+
+        </LinearLayout>
+
         <TextView
             android:id="@+id/description"
             android:layout_width="match_parent"

--- a/app/src/main/res/layout-sw600dp-land/activity_quote_detail.xml
+++ b/app/src/main/res/layout-sw600dp-land/activity_quote_detail.xml
@@ -575,7 +575,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/notes_container"
+            app:layout_constraintTop_toBottomOf="@id/displayname_container"
             android:textAppearance="@style/TextAppearance.StocksWidget.BodyLightMedium"
             style="@style/Widget.StocksWidget.TextView.BodyLightMedium"
             android:layout_marginTop="8dp"

--- a/app/src/main/res/layout-sw600dp-land/activity_quote_detail.xml
+++ b/app/src/main/res/layout-sw600dp-land/activity_quote_detail.xml
@@ -516,6 +516,60 @@
 
         </LinearLayout>
 
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:layout_constraintTop_toBottomOf="@id/notes_container"
+            android:id="@+id/displayname_header"
+            android:layout_marginBottom="8dp"
+            android:layout_marginEnd="16dp"
+            android:layout_marginStart="16dp"
+            android:layout_marginTop="8dp"
+            android:orientation="horizontal"
+            >
+
+          <TextView
+              android:layout_width="0dp"
+              android:layout_height="wrap_content"
+              android:layout_gravity="center_vertical"
+              android:layout_weight="1"
+              android:gravity="center_vertical"
+              android:text="@string/displayname"
+              style="@style/Widget.StocksWidget.TextView.LabelMedium"
+	android:textAppearance="@style/TextAppearance.StocksWidget.LabelMedium"
+              />
+
+          <ImageView
+              android:id="@+id/edit_displayname"
+              android:layout_width="20dp"
+              android:layout_height="20dp"
+              android:src="@drawable/ic_edit"
+              />
+
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:layout_constraintTop_toBottomOf="@id/displayname_header"
+            android:id="@+id/displayname_container"
+            android:visibility="gone"
+            android:layout_margin="8dp"
+            android:orientation="vertical"
+            >
+
+          <TextView
+              android:id="@+id/displayname_display"
+              android:layout_width="match_parent"
+              android:layout_height="wrap_content"
+              android:layout_marginStart="8dp"
+              android:layout_marginLeft="8dp"
+              android:layout_marginEnd="8dp"
+              android:layout_marginRight="8dp"
+              />
+
+        </LinearLayout>
+
         <TextView
             android:id="@+id/description"
             android:layout_width="match_parent"

--- a/app/src/main/res/layout/activity_displayname.xml
+++ b/app/src/main/res/layout/activity_displayname.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/activity_root"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+>
+
+    <com.google.android.material.appbar.AppBarLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+    >
+
+        <androidx.appcompat.widget.Toolbar
+            android:id="@+id/toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:navigationIcon="?attr/homeAsUpIndicator"
+            app:title="@string/displayname"
+            app:menu="@menu/menu_displayname"
+        />
+
+    </com.google.android.material.appbar.AppBarLayout>
+
+    <TextView
+        android:id="@+id/tickerName"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginLeft="16dp"
+        android:layout_marginRight="16dp"
+        android:layout_marginTop="20dp"
+        android:gravity="center"
+        tools:text="GOOG"
+        style="@style/Widget.StocksWidget.TextView.TitleLarge"
+        android:textAppearance="@style/TextAppearance.StocksWidget.TitleLarge"
+    />
+
+    <EditText
+        android:id="@+id/displaynameInputEditText"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@null"
+        android:fadeScrollbars="false"
+        android:hint="@string/add_displayname"
+        android:gravity="top"
+        android:inputType="textMultiLine|textCapSentences"
+        android:padding="8dp"
+        android:scrollbarSize="4dp"
+        android:scrollbars="vertical"
+        android:textColor="?attr/colorOnSurfaceVariant"
+        android:textSize="@dimen/large_text"
+        android:cursorVisible="true"
+    />
+
+</LinearLayout>

--- a/app/src/main/res/layout/activity_quote_detail.xml
+++ b/app/src/main/res/layout/activity_quote_detail.xml
@@ -511,6 +511,58 @@
             />
 
       </LinearLayout>
+        
+      <LinearLayout
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:id="@+id/displayname_header"
+          android:layout_marginBottom="8dp"
+          android:layout_marginEnd="16dp"
+          android:layout_marginStart="16dp"
+          android:layout_marginTop="8dp"
+          android:orientation="horizontal"
+          >
+
+        <TextView
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_vertical"
+            android:layout_weight="1"
+            android:gravity="center_vertical"
+            android:text="@string/displayname"
+            style="@style/Widget.StocksWidget.TextView.LabelMedium"
+	android:textAppearance="@style/TextAppearance.StocksWidget.LabelMedium"
+            />
+
+        <ImageView
+            android:id="@+id/edit_displayname"
+            android:layout_width="20dp"
+            android:layout_height="20dp"
+            android:src="@drawable/ic_edit"
+            />
+
+      </LinearLayout>
+
+      <LinearLayout
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:id="@+id/displayname_container"
+          android:visibility="gone"
+          android:layout_margin="8dp"
+          android:orientation="vertical"
+          >
+
+        <TextView
+            android:id="@+id/displayname_display"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            android:layout_marginLeft="8dp"
+            android:layout_marginEnd="8dp"
+            android:layout_marginRight="8dp"
+            />
+
+      </LinearLayout>
 
       <TextView
           android:id="@+id/description"

--- a/app/src/main/res/menu/menu_displayname.xml
+++ b/app/src/main/res/menu/menu_displayname.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu 
+  xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:app="http://schemas.android.com/apk/res-auto"
+>
+    <item
+        android:id="@+id/save"
+        android:icon="@drawable/ic_done"
+        android:title="@string/save"
+        android:iconTint="?attr/colorOnSurfaceVariant"
+        app:iconTint="?attr/colorOnSurfaceVariant"
+        app:showAsAction="always"/>
+</menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -180,6 +180,7 @@
   <string name="discovered_db">You have discovered the secret entrance to the DB viewer</string>
   <string name="db_tap_count">Tap %1$d more times to unlock the DB viewer</string>
   <string name="notes">Notes</string>
+  <string name="displayname">Display Name</string>
   <string name="alerts">Alerts</string>
   <string name="alert_above">Alert Above</string>
   <string name="alert_below">Alert Below</string>
@@ -192,6 +193,7 @@
   <string name="alert_dismiss">Dismiss</string>
   <string name="alerts_disabled">Alerts disabled, check settings</string>
   <string name="add_notes">Add Notes</string>
+  <string name="add_displayname">Add Display Name</string>
   <string name="add_alerts">Alerts</string>
   <string name="remove_holding">Are you sure you want to remove the entry %1$s from your portfolio?</string>
   <string name="save">Save</string>


### PR DESCRIPTION
First of all, thank you for the amazing app. I have been enjoying this widget for months. There always is a feature that I want, which is editing the name of the stock displaying on the widget. However, since it's not possible to open an issue requesting for the feature, I decided to learn Kotlin. Therefore, this is my first time developing an app on android. Kindly review my commits and do not hesitate to correct me in case I do something stupid. 

This feature allows renaming the stocks in the widget. This is particularly useful in asian stocks and currency, see pictures below. 
<p><strong>Before:</strong><br>
<img src="https://github.com/user-attachments/assets/df4086cf-6a10-472d-b16b-56fbbd55f061" width="300"></p>

<p><strong>After:</strong><br>
<img src="https://github.com/user-attachments/assets/07f77630-0fa4-4b9b-bd9a-c431c469b2d3" width="300"></p>

To edit the display name, there is a field below `notes` called `display name` in the news page. 

Nevertheless, there is a few limitations in this implementation: 
- I have not provided any translation. I suppose this would only work in English.
- The display name of the same stock in different widget would need to be the same. 