### PR TITLE
re-formatted PR #385

### DIFF
--- a/app/schemas/com.github.premnirmal.ticker.repo.QuotesDB/8.json
+++ b/app/schemas/com.github.premnirmal.ticker.repo.QuotesDB/8.json
@@ -1,0 +1,296 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 8,
+    "identityHash": "735379878be3483b838d3b2379002c6b",
+    "entities": [
+      {
+        "tableName": "QuoteRow",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`symbol` TEXT NOT NULL, `name` TEXT NOT NULL, `last_trade_price` REAL NOT NULL, `change_percent` REAL NOT NULL, `change` REAL NOT NULL, `exchange` TEXT NOT NULL, `currency` TEXT NOT NULL, `is_post_market` INTEGER NOT NULL, `annual_dividend_rate` REAL NOT NULL, `annual_dividend_yield` REAL NOT NULL, `dayHigh` REAL, `dayLow` REAL, `previousClose` REAL NOT NULL, `open` REAL, `regularMarketVolume` REAL, `peRatio` REAL, `fiftyTwoWeekLowChange` REAL, `fiftyTwoWeekLowChangePercent` REAL, `fiftyTwoWeekHighChange` REAL, `fiftyTwoWeekHighChangePercent` REAL, `fiftyTwoWeekLow` REAL, `fiftyTwoWeekHigh` REAL, `dividendDate` REAL, `earningsDate` REAL, `marketCap` REAL, `isTradeable` INTEGER, `isTriggerable` INTEGER, `marketState` TEXT, `fiftyDayAverage` REAL, `twoHundredDayAverage` REAL, PRIMARY KEY(`symbol`))",
+        "fields": [
+          {
+            "fieldPath": "symbol",
+            "columnName": "symbol",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastTradePrice",
+            "columnName": "last_trade_price",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "changeInPercent",
+            "columnName": "change_percent",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "change",
+            "columnName": "change",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "stockExchange",
+            "columnName": "exchange",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currency",
+            "columnName": "currency",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isPostMarket",
+            "columnName": "is_post_market",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "annualDividendRate",
+            "columnName": "annual_dividend_rate",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "annualDividendYield",
+            "columnName": "annual_dividend_yield",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dayHigh",
+            "columnName": "dayHigh",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "dayLow",
+            "columnName": "dayLow",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "previousClose",
+            "columnName": "previousClose",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "open",
+            "columnName": "open",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "regularMarketVolume",
+            "columnName": "regularMarketVolume",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "peRatio",
+            "columnName": "peRatio",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "fiftyTwoWeekLowChange",
+            "columnName": "fiftyTwoWeekLowChange",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "fiftyTwoWeekLowChangePercent",
+            "columnName": "fiftyTwoWeekLowChangePercent",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "fiftyTwoWeekHighChange",
+            "columnName": "fiftyTwoWeekHighChange",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "fiftyTwoWeekHighChangePercent",
+            "columnName": "fiftyTwoWeekHighChangePercent",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "fiftyTwoWeekLow",
+            "columnName": "fiftyTwoWeekLow",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "fiftyTwoWeekHigh",
+            "columnName": "fiftyTwoWeekHigh",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "dividendDate",
+            "columnName": "dividendDate",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "earningsDate",
+            "columnName": "earningsDate",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "marketCap",
+            "columnName": "marketCap",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "isTradeable",
+            "columnName": "isTradeable",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "isTriggerable",
+            "columnName": "isTriggerable",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "marketState",
+            "columnName": "marketState",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "fiftyDayAverage",
+            "columnName": "fiftyDayAverage",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "twoHundredDayAverage",
+            "columnName": "twoHundredDayAverage",
+            "affinity": "REAL",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "symbol"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "HoldingRow",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT, `quote_symbol` TEXT NOT NULL, `shares` REAL NOT NULL, `price` REAL NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "quoteSymbol",
+            "columnName": "quote_symbol",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "shares",
+            "columnName": "shares",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "price",
+            "columnName": "price",
+            "affinity": "REAL",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "PropertiesRow",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT, `properties_quote_symbol` TEXT NOT NULL, `notes` TEXT NOT NULL, `displayname` TEXT NOT NULL, `alert_above` REAL NOT NULL, `alert_below` REAL NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "quoteSymbol",
+            "columnName": "properties_quote_symbol",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notes",
+            "columnName": "notes",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayname",
+            "columnName": "displayname",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "alertAbove",
+            "columnName": "alert_above",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "alertBelow",
+            "columnName": "alert_below",
+            "affinity": "REAL",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '735379878be3483b838d3b2379002c6b')"
+    ]
+  }
+}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -41,6 +41,11 @@
             android:theme="@style/AddPositionTheme"
             android:windowSoftInputMode="adjustResize" />
         <activity
+            android:name="com.github.premnirmal.ticker.portfolio.DisplaynameActivity"
+            android:label="@string/add_displayname"
+            android:theme="@style/AddPositionTheme"
+            android:windowSoftInputMode="adjustResize" />
+        <activity
             android:name="com.github.premnirmal.ticker.portfolio.AlertsActivity"
             android:label="@string/add_alerts"
             android:theme="@style/AddPositionTheme"

--- a/app/src/main/java/com/github/premnirmal/ticker/components/AppModule.kt
+++ b/app/src/main/java/com/github/premnirmal/ticker/components/AppModule.kt
@@ -25,6 +25,7 @@ import com.github.premnirmal.ticker.repo.migrations.MIGRATION_3_4
 import com.github.premnirmal.ticker.repo.migrations.MIGRATION_4_5
 import com.github.premnirmal.ticker.repo.migrations.MIGRATION_5_6
 import com.github.premnirmal.ticker.repo.migrations.MIGRATION_6_7
+import com.github.premnirmal.ticker.repo.migrations.MIGRATION_7_8
 import com.github.premnirmal.ticker.widget.WidgetDataProvider
 import dagger.Module
 import dagger.Provides
@@ -94,6 +95,7 @@ class AppModule {
             .addMigrations(MIGRATION_4_5)
             .addMigrations(MIGRATION_5_6)
             .addMigrations(MIGRATION_6_7)
+            .addMigrations(MIGRATION_7_8)
             .build()
     }
 

--- a/app/src/main/java/com/github/premnirmal/ticker/debug/DbViewerViewModel.kt
+++ b/app/src/main/java/com/github/premnirmal/ticker/debug/DbViewerViewModel.kt
@@ -90,7 +90,7 @@ class DbViewerViewModel @Inject constructor(
             <h2>Properties</h2>
             <table>
             <tr>
-            <th>id</th><th>Symbol</th><th>Notes</th><th>Alert&nbsp;Above</th><th>Alert&nbsp;Below</th>
+            <th>id</th><th>Symbol</th><th>Notes</th><th>Display Name</th><th>Alert&nbsp;Above</th><th>Alert&nbsp;Below</th>
             </tr>
             """
                 )
@@ -171,6 +171,7 @@ class DbViewerViewModel @Inject constructor(
                                 .append("<td>${properties.id}</td>")
                                 .append("<td>${properties.quoteSymbol}</td>")
                                 .append("<td>${properties.notes}</td>")
+                                .append("<td>${properties.displayname}</td>")
                                 .append("<td>${properties.alertAbove}</td>")
                                 .append("<td>${properties.alertBelow}</td>")
                                 .append("</tr>")

--- a/app/src/main/java/com/github/premnirmal/ticker/detail/QuoteDetailScreen.kt
+++ b/app/src/main/java/com/github/premnirmal/ticker/detail/QuoteDetailScreen.kt
@@ -92,6 +92,8 @@ import com.github.premnirmal.ticker.portfolio.AlertsActivity
 import com.github.premnirmal.ticker.portfolio.HoldingsActivity
 import com.github.premnirmal.ticker.portfolio.NotesActivity
 import com.github.premnirmal.ticker.portfolio.search.AddSymbolDialog
+import com.github.premnirmal.ticker.portfolio.DisplaynameActivity
+// import com.github.premnirmal.ticker.portfolio.search.AddSuggestionScreen
 import com.github.premnirmal.ticker.ui.ContentType
 import com.github.premnirmal.ticker.ui.DateAxisFormatter
 import com.github.premnirmal.ticker.ui.ErrorState
@@ -603,6 +605,42 @@ private fun LazyGridScope.quotePositionsNotesAlerts(
                             launcher.launch(intent)
                         },
                     text = notes.ifEmpty { "--" },
+                    style = MaterialTheme.typography.bodySmall,
+                    maxLines = 4,
+                    overflow = TextOverflow.Ellipsis
+                )
+            }
+        }
+        item(span = {
+            GridItemSpan(maxLineSpan)
+        }) {
+            val context = LocalContext.current
+            var displayname by remember(quote.properties) { mutableStateOf(quote.properties?.displayname ?: "") }
+            val intent = Intent(context, DisplaynameActivity::class.java)
+            intent.putExtra(DisplaynameActivity.TICKER, quote.symbol)
+            val launcher =
+                rememberLauncherForActivityResult(
+                    ActivityResultContracts.StartActivityForResult()
+                ) { result: ActivityResult ->
+                    if (result.resultCode == Activity.RESULT_OK) {
+                        val intent = result.data
+                        displayname = intent?.getStringExtra(DisplaynameActivity.DISPLAYNAME) ?: displayname
+                    }
+                }
+            Column(
+                modifier = Modifier.clickable {
+                    launcher.launch(intent)
+                }
+            ) {
+                EditSectionHeader(title = string.displayname)
+                Text(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(top = 8.dp, bottom = 16.dp)
+                        .clickable {
+                            launcher.launch(intent)
+                        },
+                    text = displayname.ifEmpty { "--" },
                     style = MaterialTheme.typography.bodySmall,
                     maxLines = 4,
                     overflow = TextOverflow.Ellipsis

--- a/app/src/main/java/com/github/premnirmal/ticker/network/data/Properties.kt
+++ b/app/src/main/java/com/github/premnirmal/ticker/network/data/Properties.kt
@@ -9,6 +9,7 @@ import kotlinx.serialization.Serializable
 data class Properties(
     val symbol: String,
     var notes: String = "",
+    var displayname: String = "",
     var alertAbove: Float = 0.0f,
     var alertBelow: Float = 0.0f,
     var id: Long? = null

--- a/app/src/main/java/com/github/premnirmal/ticker/portfolio/DisplaynameActivity.kt
+++ b/app/src/main/java/com/github/premnirmal/ticker/portfolio/DisplaynameActivity.kt
@@ -1,0 +1,161 @@
+package com.github.premnirmal.ticker.portfolio
+
+import android.content.Intent
+import android.os.Bundle
+import androidx.activity.viewModels
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.unit.dp
+import com.github.premnirmal.ticker.base.BaseActivity
+import com.github.premnirmal.ticker.ui.TopBar
+import com.github.premnirmal.tickerwidget.R
+import dagger.hilt.android.AndroidEntryPoint
+import kotlin.getValue
+
+@AndroidEntryPoint
+class DisplaynameActivity : BaseActivity() {
+
+    companion object {
+        const val TICKER = "TICKER"
+        const val DISPLAYNAME = "DISPLAYNAME"
+    }
+
+    override val simpleName: String
+        get() = "DisplaynameActivity"
+
+    private val viewModel: DisplaynameViewModel by viewModels()
+    internal lateinit var ticker: String
+
+    override fun create(savedInstanceState: Bundle?) {
+        super.create(savedInstanceState)
+        if (intent.hasExtra(TICKER) && intent.getStringExtra(TICKER) != null) {
+            ticker = intent.getStringExtra(TICKER)!!
+        } else {
+            ticker = ""
+            appMessaging.sendSnackbar(R.string.error_symbol)
+            setResult(RESULT_CANCELED)
+            finish()
+            return
+        }
+        viewModel.symbol = ticker
+    }
+
+    @OptIn(ExperimentalMaterial3Api::class)
+    @Composable
+    override fun ShowContent() {
+        var displayname by remember(ticker) {
+            val text = viewModel.quote?.properties?.displayname ?: ""
+            mutableStateOf(
+                TextFieldValue(
+                    text = text,
+                    selection = TextRange(text.length),
+                )
+            )
+        }
+        Scaffold(
+            modifier = Modifier.imePadding(),
+            topBar = {
+                TopBar(
+                    text = stringResource(R.string.displayname),
+                    navigationIcon = {
+                        IconButton(
+                            onClick = {
+                                finish()
+                            }
+                        ) {
+                            Icon(
+                                imageVector = Icons.AutoMirrored.Default.ArrowBack,
+                                contentDescription = null,
+                            )
+                        }
+                    },
+                    actions = {
+                        IconButton(
+                            modifier = Modifier.align(Alignment.CenterVertically),
+                            onClick = {
+                                viewModel.setDisplayname(displayname.text)
+                                setResult(
+                                    RESULT_OK,
+                                    Intent().apply {
+                                        putExtra(DISPLAYNAME, displayname.text)
+                                    }
+                                )
+                                finish()
+                            }
+                        ) {
+                            Icon(
+                                painter = painterResource(R.drawable.ic_done),
+                                contentDescription = stringResource(R.string.done),
+                            )
+                        }
+                    }
+                )
+            }
+        ) { paddingValues ->
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(paddingValues)
+            ) {
+                val focusRequester = remember { FocusRequester() }
+                Text(
+                    modifier = Modifier
+                        .padding(16.dp)
+                        .align(Alignment.CenterHorizontally),
+                    text = ticker,
+                    style = MaterialTheme.typography.headlineMedium,
+                )
+                TextField(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .wrapContentHeight()
+                        .padding(vertical = 16.dp)
+                        .focusRequester(focusRequester)
+                        .verticalScroll(rememberScrollState()),
+                    value = displayname,
+                    label = { Text(text = stringResource(R.string.add_displayname)) },
+                    onValueChange = { displayname = it },
+                    colors = TextFieldDefaults.colors().copy(
+                        focusedIndicatorColor = Color.Transparent,
+                        unfocusedIndicatorColor = Color.Transparent,
+                    )
+                )
+                LaunchedEffect(Unit) {
+                    focusRequester.requestFocus()
+                }
+            }
+        }
+    }
+}
+

--- a/app/src/main/java/com/github/premnirmal/ticker/portfolio/DisplaynameViewModel.kt
+++ b/app/src/main/java/com/github/premnirmal/ticker/portfolio/DisplaynameViewModel.kt
@@ -1,0 +1,36 @@
+package com.github.premnirmal.ticker.portfolio
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.github.premnirmal.ticker.model.StocksProvider
+import com.github.premnirmal.ticker.network.data.Properties
+import com.github.premnirmal.ticker.network.data.Quote
+import com.github.premnirmal.ticker.repo.StocksStorage
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class DisplaynameViewModel @Inject constructor(
+    private val stocksProvider: StocksProvider,
+    private val stocksStorage: StocksStorage
+) : ViewModel() {
+
+    lateinit var symbol: String
+    val quote: Quote?
+        get() = stocksProvider.getStock(symbol)
+
+    fun setDisplayname(displaynameText: String) {
+        viewModelScope.launch {
+            quote?.let {
+                val properties = it.properties ?: Properties(
+                    symbol
+                )
+                it.properties = properties
+                properties.displayname = displaynameText
+                stocksStorage.saveQuoteProperties(properties)
+            }
+        }
+    }
+}
+

--- a/app/src/main/java/com/github/premnirmal/ticker/repo/QuoteDao.kt
+++ b/app/src/main/java/com/github/premnirmal/ticker/repo/QuoteDao.kt
@@ -89,7 +89,7 @@ interface QuoteDao {
         if (propertiesRow.quoteSymbol.isNotEmpty()) {
             deletePropertiesByQuoteId(propertiesRow.quoteSymbol)
         }
-        if (propertiesRow.notes.isNotEmpty() || propertiesRow.alertAbove > 0.0f || propertiesRow.alertBelow > 0.0f) {
+        if (propertiesRow.notes.isNotEmpty() || propertiesRow.displayname.isNotEmpty() || propertiesRow.alertAbove > 0.0f || propertiesRow.alertBelow > 0.0f) {
             insertProperties(propertiesRow)
         }
     }

--- a/app/src/main/java/com/github/premnirmal/ticker/repo/QuotesDB.kt
+++ b/app/src/main/java/com/github/premnirmal/ticker/repo/QuotesDB.kt
@@ -8,7 +8,7 @@ import com.github.premnirmal.ticker.repo.data.QuoteRow
 
 @Database(
     entities = [QuoteRow::class, HoldingRow::class, PropertiesRow::class],
-    version = 7,
+    version = 8,
     exportSchema = true
 )
 abstract class QuotesDB : RoomDatabase() {

--- a/app/src/main/java/com/github/premnirmal/ticker/repo/StocksStorage.kt
+++ b/app/src/main/java/com/github/premnirmal/ticker/repo/StocksStorage.kt
@@ -201,12 +201,13 @@ class StocksStorage @Inject constructor(
         return Properties(
             this.quoteSymbol,
             this.notes,
+            this.displayname,
             this.alertAbove,
             this.alertBelow
         )
     }
 
     private fun Properties.toPropertiesRow(): PropertiesRow {
-        return PropertiesRow(this.id, this.symbol, this.notes, this.alertAbove, this.alertBelow)
+        return PropertiesRow(this.id, this.symbol, this.notes, this.displayname, this.alertAbove, this.alertBelow)
     }
 }

--- a/app/src/main/java/com/github/premnirmal/ticker/repo/data/PropertiesRow.kt
+++ b/app/src/main/java/com/github/premnirmal/ticker/repo/data/PropertiesRow.kt
@@ -9,6 +9,7 @@ data class PropertiesRow(
     @PrimaryKey(autoGenerate = true) var id: Long? = null,
     @ColumnInfo(name = "properties_quote_symbol") val quoteSymbol: String,
     @ColumnInfo(name = "notes") val notes: String = "",
+    @ColumnInfo(name = "displayname") val displayname: String = "",
     @ColumnInfo(name = "alert_above") val alertAbove: Float = 0.0f,
     @ColumnInfo(name = "alert_below") val alertBelow: Float = 0.0f
 )

--- a/app/src/main/java/com/github/premnirmal/ticker/repo/migrations/Migrations.kt
+++ b/app/src/main/java/com/github/premnirmal/ticker/repo/migrations/Migrations.kt
@@ -104,3 +104,9 @@ val MIGRATION_6_7 = object : Migration(6, 7) {
         database.execSQL("ALTER TABLE `$tableName` ADD COLUMN `twoHundredDayAverage` REAL;")
     }
 }
+
+val MIGRATION_7_8 = object : Migration(7, 8) {
+    override fun migrate(database: SupportSQLiteDatabase) {
+        database.execSQL("ALTER TABLE PropertiesRow ADD COLUMN displayname TEXT NOT NULL DEFAULT ''")
+    }
+}

--- a/app/src/main/java/com/github/premnirmal/ticker/widget/RemoteStockViewAdapter.kt
+++ b/app/src/main/java/com/github/premnirmal/ticker/widget/RemoteStockViewAdapter.kt
@@ -85,7 +85,13 @@ class RemoteStockViewAdapter(private val widgetId: Int) : RemoteViewsService.Rem
             val gainLossPercentString = SpannableString(gainLossPercentFormatted)
             val priceString = SpannableString(priceFormatted)
 
-            remoteViews.setTextViewText(R.id.ticker, stock.symbol)
+            remoteViews.setTextViewText(
+                R.id.ticker,
+                stock.properties?.displayname
+                    .takeUnless { it.isNullOrBlank() }
+                    ?: stock.symbol
+            )
+
             remoteViews.setTextViewText(
                 R.id.holdings,
                 if (widgetData.isCurrencyEnabled()) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -180,6 +180,7 @@
   <string name="discovered_db">You have discovered the secret entrance to the DB viewer</string>
   <string name="db_tap_count">Tap %1$d more times to unlock the DB viewer</string>
   <string name="notes">Notes</string>
+  <string name="displayname">Display Name</string>
   <string name="alerts">Alerts</string>
   <string name="alert_above">Alert Above</string>
   <string name="alert_below">Alert Below</string>
@@ -192,6 +193,7 @@
   <string name="alert_dismiss">Dismiss</string>
   <string name="alerts_disabled">Alerts disabled, check settings</string>
   <string name="add_notes">Add Notes</string>
+  <string name="add_displayname">Add Display Name</string>
   <string name="add_alerts">Alerts</string>
   <string name="remove_holding">Are you sure you want to remove the entry %1$s from your portfolio?</string>
   <string name="save">Save</string>


### PR DESCRIPTION
Hi again, the author of PR #385. 

This PR is currently a draft.

I have migrated most of the logics from the previous PR to the current format by running detect locally on my change (and copy-paste) 

However, I still cannot reproduce the change made to the layouts, and thus the changes made to these following files should be migrated to this PR first for the feature to be completed. 
- `app/src/main/kotlin/com/github/premnirmal/ticker/news/QuoteDetailActivity.kt`
- `app/src/main/res/layout-land/activity_quote_detail.xml`
- `app/src/main/res/layout-sw600dp-land/activity_quote_detail.xml`
- `app/src/main/res/layout/activity_quote_detail.xml`
- `app/src/main/res/layout/activity_displayname.xml`
- `app/src/main/res/menu/menu_displayname.xml`
- `app/src/main/kotlin/com/github/premnirmal/ticker/portfolio/AddDisplaynameActivity.kt`
- `app/src/main/kotlin/com/github/premnirmal/ticker/portfolio/DisplaynameViewModel.kt`

Is there a way I can reproduce the changes made to the layouts, or would it be easier to just manually make the changes needed? pinging @premnirmal 

Also, this is currently untested.