### PR TITLE
Fix crash when typing in alert price field

### DIFF
--- a/app/src/main/java/com/github/premnirmal/ticker/portfolio/AlertsActivity.kt
+++ b/app/src/main/java/com/github/premnirmal/ticker/portfolio/AlertsActivity.kt
@@ -114,12 +114,12 @@ class AlertsActivity : BaseActivity() {
                     }
                     var alertAboveText by remember(ticker) {
                         mutableStateOf(
-                            if (alertAbove > 0f) alertAbove.toString() else ""
+                            if (alertAbove > 0f) decimalFormatter.cleanup(alertAbove.toString()) else ""
                         )
                     }
                     var alertBelowText by remember(ticker) {
                         mutableStateOf(
-                            if (alertBelow > 0f) alertBelow.toString() else ""
+                            if (alertBelow > 0f) decimalFormatter.cleanup(alertBelow.toString()) else ""
                         )
                     }
                     TextField(
@@ -187,18 +187,20 @@ class AlertsActivity : BaseActivity() {
         val alertAboveText = alertAboveText.ifEmpty { "0" }
         val alertBelowText = alertBelowText.ifEmpty { "0" }
         val alertAbove = try {
-            val parsed = numberFormat.parse(alertAboveText)!!.toFloat()
+            val parsed = numberFormat.parse(alertAboveText)?.toFloat()
+                ?: throw NumberFormatException("Unable to parse: $alertAboveText")
             isErrorAlertAbove = false
             parsed
-        } catch (e: NumberFormatException) {
+        } catch (e: Exception) {
             isErrorAlertAbove = true
             0f
         }
         val alertBelow = try {
-            val parsed = numberFormat.parse(alertBelowText)!!.toFloat()
+            val parsed = numberFormat.parse(alertBelowText)?.toFloat()
+                ?: throw NumberFormatException("Unable to parse: $alertBelowText")
             isErrorAlertBelow = false
             parsed
-        } catch (e: NumberFormatException) {
+        } catch (e: Exception) {
             isErrorAlertBelow = true
             0f
         }

--- a/app/src/main/java/com/github/premnirmal/ticker/portfolio/DecimalFormatter.kt
+++ b/app/src/main/java/com/github/premnirmal/ticker/portfolio/DecimalFormatter.kt
@@ -12,6 +12,7 @@ class DecimalFormatter(
     private val decimalSeparator = symbols.decimalSeparator
 
     fun cleanup(input: String): String {
+        if (input.isEmpty()) return ""
         if (input.matches("\\D".toRegex())) return ""
         if (input.matches("0+".toRegex())) return "0"
         val sb = StringBuilder()
@@ -21,8 +22,11 @@ class DecimalFormatter(
                 sb.append(char)
                 continue
             }
-            if (char == decimalSeparator && !hasDecimalSep && sb.isNotEmpty()) {
-                sb.append(char)
+            // Accept either the locale decimal separator or '.' so that
+            // pre-populated values from Float.toString() (which always uses '.')
+            // work regardless of locale.
+            if ((char == decimalSeparator || char == '.') && !hasDecimalSep && sb.isNotEmpty()) {
+                sb.append(decimalSeparator)
                 hasDecimalSep = true
             }
         }
@@ -50,18 +54,10 @@ class DecimalInputVisualTransformation(
             spanStyles = text.spanStyles,
             paragraphStyles = text.paragraphStyles
         )
-        val offsetMapping = FixedCursorOffsetMapping(
-            contentLength = inputText.length,
-            formattedContentLength = formattedNumber.length
-        )
-        return TransformedText(newText, offsetMapping)
+        // formatForVisual preserves character count (it only re-joins using the same
+        // decimal separator), so using Identity is both correct and avoids the
+        // broken constant-offset mapping that was crashing the TextField when the
+        // field was pre-populated with an existing alert value.
+        return TransformedText(newText, OffsetMapping.Identity)
     }
-}
-
-private class FixedCursorOffsetMapping(
-    private val contentLength: Int,
-    private val formattedContentLength: Int,
-) : OffsetMapping {
-    override fun originalToTransformed(offset: Int): Int = formattedContentLength
-    override fun transformedToOriginal(offset: Int): Int = contentLength
 }


### PR DESCRIPTION
## Summary

Fixes a crash when typing into the **alert price** fields on the Alerts screen. As soon as the user tapped the "Alert above" or "Alert below" field and typed a digit, the app crashed.

## Root cause

`DecimalInputVisualTransformation` in `DecimalFormatter.kt` used a custom `FixedCursorOffsetMapping` whose `originalToTransformed` / `transformedToOriginal` returned constants (the lengths captured at construction time) instead of the actual requested offset. The visual string produced by `formatForVisual` is the same length as the input, so Compose's `TextField` would hand the mapping a valid offset but receive an out-of-range constant back, which triggers an `IllegalArgumentException` (`OffsetMapping.originalToTransformed returned invalid mapping`) and crashes the activity on the first keystroke.

A second latent bug compounded this: `saveAlerts()` used `numberFormat.parse(text)!!.toFloat()`, which throws an unchecked `NullPointerException` when parsing fails (the `catch` only handled `NumberFormatException`), and the pre-populated text used `Float.toString()` (always `.`-separated) while `cleanup()` only accepted the current locale's decimal separator, so existing alert values could be dropped or mis-parsed in non-`.` locales.

## Fix

- `DecimalFormatter.kt`
  - Drop the broken `FixedCursorOffsetMapping` entirely and use `OffsetMapping.Identity` in `DecimalInputVisualTransformation.filter`. This is safe because `formatForVisual` is length-preserving (it only replaces the decimal separator 1:1).
  - `cleanup()` now accepts both `.` and the locale's decimal separator, and returns `""` for empty input so `Float.toString()` values pre-populate correctly in any locale.
- `AlertsActivity.kt`
  - Normalize pre-populated `alertAbove` / `alertBelow` floats through `decimalFormatter.cleanup(...)` so they render correctly in the visual transformation regardless of locale.
  - Replace `numberFormat.parse(text)!!.toFloat()` with a safe `?.toFloat() ?: throw NumberFormatException(...)` and widen the `catch` to `Exception` so malformed input is surfaced via the existing toast instead of crashing.

## Testing

- Built `:app:assembleDevDebug` (APK ~20 MB) and installed it on a real device.
- Verified typing digits and a decimal separator in both alert fields no longer crashes, editing pre-existing alert values works, empty input is handled, and saving/clearing alerts still behaves correctly.
