### PR TITLE
Filter ticker news by exact symbol or company

### DIFF
--- a/app/src/main/java/com/github/premnirmal/ticker/network/data/Quote.kt
+++ b/app/src/main/java/com/github/premnirmal/ticker/network/data/Quote.kt
@@ -180,22 +180,42 @@ data class Quote constructor(
     }
 
     fun newsQuery(): String {
-        return "${if (symbol.contains(
-                "."
-            )
-        ) {
-            symbol.substring(
-                0,
-                symbol.indexOf('.')
-            )
+        return "${newsTicker()} ${companyNameForNews()} stock"
+    }
+
+    fun matchesNewsArticle(article: NewsArticle): Boolean {
+        val articleText = "${article.title.orEmpty()} ${article.description.orEmpty()}"
+        val ticker = newsTicker()
+        val companyName = companyNameForNews()
+        return ticker.isNotBlank() && articleText.containsWholeTerm(ticker, ignoreCase = false) ||
+            companyName.isNotBlank() && articleText.containsWholeTerm(companyName, ignoreCase = true)
+    }
+
+    private fun newsTicker(): String {
+        return if (symbol.contains(".")) {
+            symbol.substring(0, symbol.indexOf('.'))
         } else {
             symbol
-        }} ${name.split(
-            " "
-        ).toMutableList().apply { removeAll(
-            arrayOf("Inc.", "Corporation", "PLC", "ORD")
-        )
-        }.take(3).joinToString(" ")} stock"
+        }
+    }
+
+    private fun companyNameForNews(): String {
+        return name.split(" ")
+            .toMutableList()
+            .apply {
+                removeAll(arrayOf("Inc.", "Corporation", "PLC", "ORD"))
+            }
+            .take(3)
+            .joinToString(" ")
+    }
+
+    private fun String.containsWholeTerm(
+        term: String,
+        ignoreCase: Boolean
+    ): Boolean {
+        val options = if (ignoreCase) setOf(RegexOption.IGNORE_CASE) else emptySet()
+        val pattern = "(?<![A-Za-z0-9])${Regex.escape(term)}(?![A-Za-z0-9])"
+        return Regex(pattern, options).containsMatchIn(this)
     }
 
     val isMarketOpen: Boolean

--- a/app/src/main/java/com/github/premnirmal/ticker/news/QuoteDetailViewModel.kt
+++ b/app/src/main/java/com/github/premnirmal/ticker/news/QuoteDetailViewModel.kt
@@ -293,7 +293,9 @@ class QuoteDetailViewModel @Inject constructor(
         val result = newsProvider.fetchNewsForQuery(query)
         when {
             result.wasSuccessful -> {
-                val newsFeeds = result.data.map { ArticleNewsFeed(it) }
+                val newsFeeds = result.data
+                    .filter { quote.matchesNewsArticle(it) }
+                    .map { ArticleNewsFeed(it) }
                 if (truncate) {
                     _newsData.value = newsFeeds.take(8)
                 } else {

--- a/app/src/test/java/com/github/premnirmal/ticker/network/data/QuoteTest.kt
+++ b/app/src/test/java/com/github/premnirmal/ticker/network/data/QuoteTest.kt
@@ -1,0 +1,56 @@
+package com.github.premnirmal.ticker.network.data
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class QuoteTest {
+
+    @Test
+    fun matchesNewsArticleByCompanyName() {
+        val quote = Quote(symbol = "NET", name = "Cloudflare Inc.")
+        val article = NewsArticle(
+            title = "Cloudflare expands its developer platform",
+            url = "https://example.com/cloudflare",
+            publishedAt = "Tue, 01 Jan 2026 00:00:00 GMT"
+        )
+
+        assertTrue(quote.matchesNewsArticle(article))
+    }
+
+    @Test
+    fun matchesNewsArticleByUppercaseTickerOnly() {
+        val quote = Quote(symbol = "NET", name = "Cloudflare Inc.")
+        val article = NewsArticle(
+            title = "NET shares rise after earnings",
+            url = "https://example.com/net",
+            publishedAt = "Tue, 01 Jan 2026 00:00:00 GMT"
+        )
+
+        assertTrue(quote.matchesNewsArticle(article))
+    }
+
+    @Test
+    fun doesNotMatchLowercaseCommonWordTicker() {
+        val quote = Quote(symbol = "NET", name = "Cloudflare Inc.")
+        val article = NewsArticle(
+            title = "Company reports higher net income",
+            url = "https://example.com/net-income",
+            publishedAt = "Tue, 01 Jan 2026 00:00:00 GMT"
+        )
+
+        assertFalse(quote.matchesNewsArticle(article))
+    }
+
+    @Test
+    fun doesNotMatchTickerInsideAnotherWord() {
+        val quote = Quote(symbol = "NET", name = "Cloudflare Inc.")
+        val article = NewsArticle(
+            title = "Internet providers face new rules",
+            url = "https://example.com/internet",
+            publishedAt = "Tue, 01 Jan 2026 00:00:00 GMT"
+        )
+
+        assertFalse(quote.matchesNewsArticle(article))
+    }
+}


### PR DESCRIPTION
Fixes #440

## Summary
- filters quote news results against the selected quote before rendering
- matches the ticker only as an uppercase whole term, so `NET` does not match `net income` or `internet`
- still accepts articles that mention the company name, e.g. Cloudflare
- adds focused coverage for company-name, uppercase ticker, lowercase common-word, and embedded-word cases

## Validation
- `git diff --check HEAD~1..HEAD`
- `./gradlew app:testDevDebugUnitTest --tests "com.github.premnirmal.ticker.network.data.QuoteTest"` could not run locally because this machine has no Java Runtime installed