### PR TITLE
Use save label in add symbol dialog

### DIFF
--- a/app/src/main/java/com/github/premnirmal/ticker/portfolio/search/AddSymbolDialog.kt
+++ b/app/src/main/java/com/github/premnirmal/ticker/portfolio/search/AddSymbolDialog.kt
@@ -139,7 +139,7 @@ private fun AddSymbolDialogInternal(
                         onDismissRequest()
                         openDialog.value = false
                     }) {
-                        Text(text = stringResource(id = string.done))
+                        Text(text = stringResource(id = string.save))
                     }
                 }
             }

--- a/app/src/main/java/com/github/premnirmal/ticker/portfolio/search/AddSymbolDialog.kt
+++ b/app/src/main/java/com/github/premnirmal/ticker/portfolio/search/AddSymbolDialog.kt
@@ -139,7 +139,7 @@ private fun AddSymbolDialogInternal(
                         onDismissRequest()
                         openDialog.value = false
                     }) {
-                        Text(text = stringResource(id = string.alert_dismiss))
+                        Text(text = stringResource(id = string.done))
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- use the existing `done` string for the add-symbol dialog close button instead of the alert-specific dismiss string
- this avoids showing the Italian alert text `Ignora` in the add-symbol flow

Fixes #427

## Tests
- `git diff --check`

Build/tests not run locally because this Mac does not have a Java Runtime installed (`java -version` fails before Gradle can start).